### PR TITLE
#16 utc_timestamp

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -4,12 +4,13 @@ from os import getenv
 from sqlalchemy import engine_from_config, pool
 
 from alembic import context
+from gpyt_eventbus.settings import StandardSettings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 config.set_main_option(
-    "sqlalchemy.url", getenv("GPYT_DB_DSN", "sqlite:///gpyt_eventbus.db")
+    "sqlalchemy.url", getenv("GPYT_DB_DSN", StandardSettings().db_dsn)
 )
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/alembic/versions/84044029dca9_create_event_table.py
+++ b/alembic/versions/84044029dca9_create_event_table.py
@@ -27,7 +27,6 @@ def upgrade():
             "timestamp",
             sa.DateTime(),
             nullable=False,
-            server_default=sa.func.utc_timestamp(),
         ),
         sa.Column("aggregate_name", sa.String(), nullable=True),
         sa.Column("revision", sa.Integer(), nullable=False, server_default="0"),


### PR DESCRIPTION
- alembic uses settings object
- migration does not use utc_timestamp as server_default